### PR TITLE
Update GitHub workflow to allow for manual builds

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,8 @@
 name: Continuous Integration
 # This workflow is triggered on pushes to the repository.
-on: [push]
+on:
+  - push
+  - workflow_dispatch
 
 jobs:
   build:


### PR DESCRIPTION
This is to address #5.

I will probably need some help testing this since I don't think I have enough permissions. It would be great if we could restore my ability to run the build so that I can update the xenorchestra provider's docs without any help.